### PR TITLE
expose block timestamp in transaction

### DIFF
--- a/src/web3tx.js
+++ b/src/web3tx.js
@@ -21,6 +21,9 @@ module.exports = function web3tx(fn, msg, expects = {}) {
         tx = await web3.eth.getTransaction(transactionHash);
         r.receipt = receipt;
 
+        let block = await web3.eth.getBlock(tx.blockNumber);
+        r.timestamp = block.timestamp;
+
         let cost = web3.utils.toBN(receipt.gasUsed * tx.gasPrice);
         r.txCost = cost;
 

--- a/test/web3tx.test.js
+++ b/test/web3tx.test.js
@@ -49,6 +49,7 @@ contract("web3tx", accounts => {
             }]
         })(10);
         assert.isDefined(tx.receipt);
+        assert.isDefined(tx.timestamp);
         assert.isTrue(tx.txCost > 100000);
         await assertFailure(web3tx(tester.setValue, "tester.setValue 10 expecting 11", {
             inLogs: [{


### PR DESCRIPTION
It's a sugar syntax change that helps getting the real timestamp of a transaction.